### PR TITLE
Change template gh workflow, fix old project template path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: v2.5.0
     hooks:
       - id: check-yaml
-        exclude: ^{{ cookiecutter.project_name }}/.github/
+        exclude: ^{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/.github/
       - id: end-of-file-fixer
         exclude: LICENSE
 
@@ -17,7 +17,7 @@ repos:
       - id: pyupgrade
         name: pyupgrade
         entry: poetry run pyupgrade --py37-plus
-        exclude: ^{{ cookiecutter.project_name }}/
+        exclude: ^{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/
         types: [python]
         language: system
 
@@ -26,7 +26,7 @@ repos:
       - id: isort
         name: isort
         entry: poetry run isort --settings-path pyproject.toml
-        exclude: ^{{ cookiecutter.project_name }}/
+        exclude: ^{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/
         types: [python]
         language: system
 
@@ -35,6 +35,6 @@ repos:
       - id: black
         name: black
         entry: poetry run black --config pyproject.toml
-        exclude: ^{{ cookiecutter.project_name }}/
+        exclude: ^{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/
         types: [python]
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: v2.5.0
     hooks:
       - id: check-yaml
-        exclude: ^{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/.github/
+        exclude: ^\{\{ cookiecutter\.project_name\.lower\(\).replace\(' ', '_'\)\.replace\('-', '_'\) \}\}\/\.github\/
       - id: end-of-file-fixer
         exclude: LICENSE
 
@@ -17,7 +17,7 @@ repos:
       - id: pyupgrade
         name: pyupgrade
         entry: poetry run pyupgrade --py37-plus
-        exclude: ^{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/
+        exclude: ^\{\{ cookiecutter\.project_name\.lower\(\).replace\(' ', '_'\)\.replace\('-', '_'\) \}\}\/
         types: [python]
         language: system
 
@@ -26,7 +26,7 @@ repos:
       - id: isort
         name: isort
         entry: poetry run isort --settings-path pyproject.toml
-        exclude: ^{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/
+        exclude: ^\{\{ cookiecutter\.project_name\.lower\(\).replace\(' ', '_'\)\.replace\('-', '_'\) \}\}\/
         types: [python]
         language: system
 
@@ -35,6 +35,6 @@ repos:
       - id: black
         name: black
         entry: poetry run black --config pyproject.toml
-        exclude: ^{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/
+        exclude: ^\{\{ cookiecutter\.project_name\.lower\(\).replace\(' ', '_'\)\.replace\('-', '_'\) \}\}\/
         types: [python]
         language: system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ warn_unused_ignores = true
 [tool.pytest.ini_options]
 # https://docs.pytest.org/en/6.2.x/customize.html#pyproject-toml
 # Directories that are not visited by pytest collector:
-norecursedirs =["{{ cookiecutter.project_name }}", "hooks", "*.egg", ".eggs", "dist", "build", "docs", ".tox", ".git", "__pycache__"]
+norecursedirs =["{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}", "hooks", "*.egg", ".eggs", "dist", "build", "docs", ".tox", ".git", "__pycache__"]
 doctest_optionflags = ["NUMBER", "NORMALIZE_WHITESPACE", "IGNORE_EXCEPTION_DETAIL"]
 
 # Extra options:

--- a/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/.github/workflows/build.yml
+++ b/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["{% endraw %}{{ cookiecutter.minimal_python_version }}"{%- if cookiecutter.minimal_python_version != '3.9' -%}, "3.9"{% endif %}]{% raw %}
+        python-version: ["{% endraw %}{{ cookiecutter.minimal_python_version }}"]{% raw %}
 
     steps:
     - uses: actions/checkout@v2

--- a/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/.github/workflows/codeql-analysis.yml
+++ b/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,54 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [master]
+  schedule:
+    - cron: '0 6 * * 3'
+
+jobs:
+  analyse:
+    name: Analyse
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
+
+    # If this run was triggered by a pull request event, then checkout
+    # the head of the pull request instead of the merge commit.
+    - run: git checkout HEAD^2
+      if: ${{ github.event_name == 'pull_request' }}
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      # Override language selection by uncommenting this and choosing your languages
+      with:
+        languages: python
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/pyproject.toml
+++ b/{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 
 {% if cookiecutter.create_example_template == 'cli' -%}[tool.poetry.scripts]
 # Entry points for the package https://python-poetry.org/docs/pyproject/#scripts
-"{{ cookiecutter.project_name }}" = "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}.__main__:app"{%- endif %}
+"{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}" = "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}.__main__:app"{%- endif %}
 
 [tool.poetry.dependencies]
 python = "^{{ cookiecutter.minimal_python_version }}"
@@ -143,7 +143,7 @@ addopts = [
 source = ["tests"]
 
 [coverage.paths]
-source = "{{ cookiecutter.project_name }}"
+source = "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}
 
 [coverage.run]
 branch = true


### PR DESCRIPTION
## Description

- Fixed pre-commit excludes
- Fixed pyproject old path
- Added gh workflow to project template as well (codeql)

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/TezRomacH/python-package-template/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/TezRomacH/python-package-template/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in `Google` format for all the methods and classes that I used.
